### PR TITLE
SA 190/classify for SOC - Repair data loading and path resolution

### DIFF
--- a/src/occupational_classification_utils/embed/embedding.py
+++ b/src/occupational_classification_utils/embed/embedding.py
@@ -13,7 +13,7 @@ from autocorrect import Speller
 from langchain.docstore.document import Document
 from langchain_community.embeddings import HuggingFaceEmbeddings, VertexAIEmbeddings
 from langchain_community.vectorstores import Chroma  # pylint: disable=no-name-in-module
-from occupational_classification.data_access.soc_data_access import (
+from occupational_classification_utils.utils.soc_data_access import (
     load_soc_index,
 )
 from occupational_classification.hierarchy.soc_hierarchy import SOC
@@ -49,16 +49,16 @@ def get_config() -> dict[str, dict[str, str]]:
         },
         "lookups": {
             "soc_index": (
-                "src/occupational_classification_utils/data/soc_index/"
-                "soc2020volume2thecodingindexexcel16102024.xlsx"
+                "occupational_classification_utils.data.soc_index",
+                "soc2020volume2thecodingindexexcel16102024.xlsx",
             ),
             "soc_structure": (
-                "src/occupational_classification_utils/data/soc_index/"
-                "soc2020volume1structureanddescriptionofunitgroupsexcel16102024.xlsx"
+                "occupational_classification_utils.data.soc_index",
+                "soc2020volume1structureanddescriptionofunitgroupsexcel16102024.xlsx",
             ),
             "soc_condensed": (
-                "src/occupational_classification_utils/data/example/"
-                "soc_4d_condensed.txt"
+                "occupational_classification_utils.data.example",
+                "soc_4d_condensed.txt",
             ),
         },
     }

--- a/src/occupational_classification_utils/llm/llm.py
+++ b/src/occupational_classification_utils/llm/llm.py
@@ -24,10 +24,6 @@ from langchain.chains.llm import LLMChain
 from langchain.output_parsers import PydanticOutputParser
 from langchain_google_vertexai import VertexAI
 from langchain_openai import ChatOpenAI
-from occupational_classification.data_access.soc_data_access import (
-    load_soc_index,
-    load_soc_structure,
-)
 from occupational_classification.hierarchy.soc_hierarchy import load_hierarchy
 from occupational_classification.meta.soc_meta import SocDB, SocMeta
 
@@ -42,6 +38,10 @@ from occupational_classification_utils.llm.prompt import (
 from occupational_classification_utils.models.response_model import (
     SocResponse,
     SurveyAssistSocResponse,
+)
+from occupational_classification_utils.utils.soc_data_access import (
+    load_soc_index,
+    load_soc_structure,
 )
 
 logger = logging.getLogger(__name__)

--- a/src/occupational_classification_utils/llm/prompt.py
+++ b/src/occupational_classification_utils/llm/prompt.py
@@ -31,7 +31,7 @@ from occupational_classification_utils.models.response_model import (
     SocResponse,
     SurveyAssistSocResponse,
 )
-from occupational_classification_utils.utils.common_utils import (
+from occupational_classification_utils.utils.soc_data_access import (
     load_text_from_config,
 )
 

--- a/src/occupational_classification_utils/utils/soc_data_access.py
+++ b/src/occupational_classification_utils/utils/soc_data_access.py
@@ -1,0 +1,100 @@
+"""Provides data access for key files.
+
+This module contains utility functions to load and process data from
+SOC-related Excel files. The filepaths for these files are defined in
+the configuration function in `embedding.py`.
+"""
+
+import logging
+from importlib.resources import files
+
+import pandas as pd
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def load_soc_index(resource_ref: tuple[str, str]) -> pd.DataFrame:
+    """Loads the SOC index from an Excel file.
+
+    The SOC index provides a list of activities and their associated SOC codes.
+
+    Args:
+        resource_ref (tuple): A tuple containing the package name and filename
+            of the Excel file containing the SOC index.
+
+    Returns:
+        pd.DataFrame: A DataFrame containing the SOC index with columns
+        `code` and `title`.
+    """
+    pkg, filename = resource_ref
+    file_path = files(pkg).joinpath(filename)
+
+    logger.info("Loading SOC index from %s", file_path)
+
+    soc_index_df = pd.read_excel(
+        file_path,
+        sheet_name="Alphabetical Index",
+        skiprows=2,
+        usecols=["SOC 2020", "Title"],
+        dtype=str,
+    )
+
+    soc_index_df.columns = ["code", "title"]
+
+    return soc_index_df
+
+
+def load_soc_structure(resource_ref: tuple[str, str]) -> pd.DataFrame:
+    """Loads the SOC structure from an Excel file.
+
+    This function loads a worksheet containing all the levels and names
+    of the UK SOC 2020 hierarchy.
+
+    Args:
+        resource_ref (tuple): A tuple containing the package name and filename
+            of the Excel file containing the SOC structure.
+
+    Returns:
+        pd.DataFrame: A DataFrame containing the SOC structure.
+    """
+    pkg, filename = resource_ref
+    file_path = files(pkg).joinpath(filename)
+
+    logger.info("Loading SOC structure from %s", file_path)
+
+    soc_df = pd.read_excel(
+        file_path,
+        sheet_name="SOC2020 descriptions",
+        dtype=str,
+    )
+
+    # Clean up column names to match what the SOC meta library expects
+    soc_df.columns = soc_df.columns.str.replace('\n', ' ').str.lower().str.replace(' ', '_')
+    # Handle specific case where 'soc_2020_unit_group' should remain as 'soc_2020_unit_group'
+    soc_df.columns = soc_df.columns.str.replace('soc_2020_', 'soc2020_').str.replace('soc2020_unit_group', 'soc_2020_unit_group')
+
+    return soc_df
+
+
+def load_text_from_config(config_section: tuple[str, str]) -> str:
+    """Loads text content from a configuration file.
+
+    This function reads the content of a text file specified by the given
+    configuration section and returns it as a string.
+
+    Args:
+        config_section (tuple[str, str]): A tuple containing the package name
+            and the filename of the configuration file.
+
+    Returns:
+        str: The content of the configuration file as a string.
+
+    """
+    pkg, filename = config_section
+    file_path = files(pkg).joinpath(filename)
+
+    logger.info("Loading text from %s", file_path)
+
+    with file_path.open(encoding="utf-8") as f:
+        return f.read() 


### PR DESCRIPTION
# 📌 Pull Request Template

> **Please complete all sections**

## ✨ Summary

The PR is required for https://github.com/ONSdigital/survey-assist-api/pull/16

This PR fixes data loading and path resolution issues in the SOC classification utils library to enable proper integration with the survey-assist-api. The changes ensure the library can be used as a dependency without requiring manual file copying or path manipulation.

SOC classification library (soc-classification-utils) uses relative paths in its configuration, but when used as a dependency in the survey-assist-api project, these paths break because they're resolved relative to the wrong directory.

What's Happening: Library config expects files at: src/occupational_classification_utils/data/... When running from survey-assist-api, it looks for: survey-assist-api/src/occupational_classification_utils/data/... Files actually exist at: soc-classification-utils/src/occupational_classification_utils/data/... 

Why This Happens: The library seems to have been designed to be run from its own directory. It uses relative paths that assume the current working directory is the library root. When used as a dependency, the working directory is the consuming project

The Files Needed: `soc_4d_condensed.txt`, `soc2020volume1structureanddescriptionofunitgroupsexcel16102024.xlsx`, `soc2020volume2thecodingindexexcel16102024.xlsx`


## 📜 Changes Introduced

<!-- List key changes made in this PR. Consider bullet points for readability. -->

- **Fix:** updated `get_config()` to use package-relative paths instead of hardcoded relative paths
- **Feat:** created new `soc_data_access.py` module with data loading functions using `importlib.resources.files()` - same pattern as sic i.e. sic_data_access.py in sic utils library 
- **Refactor:** updated imports in `embedding.py` and `prompt.py` to use the new data access module
- **Fix:** resolved column name mismatches in Excel data loading by cleaning column names
- **Chore:** removed redundant file copying requirements 

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

<!-- Describe how reviewers can verify your changes. Include test commands if applicable. -->

### 1. Run the SOC Classification Utils Tests

```bash
make all-tests
```

### 2. Test Data Loading Functions

```bash
poetry run python -c "from src.occupational_classification_utils.utils.soc_data_access import load_text_from_config, load_soc_structure; from src.occupational_classification_utils.embed.embedding import get_config; config = get_config(); text_data = load_text_from_config(config['lookups']['soc_condensed']); print(f'✓ Loaded {len(text_data)} characters of text data'); excel_data = load_soc_structure(config['lookups']['soc_structure']); print(f'✓ Loaded Excel data with columns: {list(excel_data.columns)}')"
```

This will test that the new data access functions can load both text and Excel files using package-relative paths.

### 3. Test SOC Classification

```bash
poetry run python -c "from src.occupational_classification_utils.utils.soc_data_access import load_text_from_config; from src.occupational_classification_utils.embed.embedding import get_config; config = get_config(); result = load_text_from_config(config['lookups']['soc_condensed']); print(f'✓ Successfully loaded {len(result)} characters of text')"
```

This will test that the SOC classification data loading works with the updated configuration.

### Key Changes to Verify

- **Path Resolution:** Library works without copying data files to external directories
- **Column Names:** Excel files load with clean column names (no newlines, spaces replaced with underscores)
- **Integration:** survey-assist-api successfully uses SOC classification library as dependency
- **No Redundancy:** No need to copy `soc_4d_condensed.txt` or Excel files to survey-assist-api directory 