### PR TITLE
SA-631 update dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ langchain-openai = "0.3.21"
 langchain-huggingface = "0.3.0"
 pydantic = "^2.11.1"
 ipykernel = "^6.29.5"
-soc-classification-library = { git = "https://github.com/ONSdigital/soc-classification-library.git", tag = "v0.1.4" }
+soc-classification-library = { git = "https://github.com/ONSdigital/soc-classification-library.git", tag = "v0.1.5" }
 survey-assist-utils = {git = "https://github.com/ONSdigital/survey-assist-utils.git", tag = "v0.0.7"}
 jupytext = "^1.17.2"
 posthog = ">=2.4.0,<6.0.0"


### PR DESCRIPTION
# 📌 Pull Request – SA-631

## ✨ Summary

Update `soc-classification-library` dependency in `soc-classification-utils` to the tagged remote release `v0.1.5`.

Depends on https://github.com/ONSdigital/soc-classification-library/pull/48

## 📜 Changes Introduced

- Updated `pyproject.toml` to use:
  - `soc-classification-library = { git = "https://github.com/ONSdigital/soc-classification-library.git", tag = "v0.1.5" }`

## 🔍 How to Test

```bash
poetry lock --no-update
poetry install --no-root
poetry show soc-classification-library
```
> **Current CI status**
>
> Lint fails because because this PR  pins `soc-classification-library` to `v0.1.5`, which has not yet been released. 
